### PR TITLE
✨ レシートを解析する機能の引数をbytesにした (#16)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,13 +1,6 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, UploadFile, File
 from src.receipt_scanner_model import analyze
-from pydantic import BaseModel
 import tomllib
-
-
-# TODO: fileの型をbytesに変更する
-class Receipt(BaseModel):
-    file: str
-
 
 with open("pyproject.toml", "rb") as f:
     data = tomllib.load(f)
@@ -25,9 +18,9 @@ async def root():
 
 
 @app.post("/receipt-analyze")
-async def receipt_analyze(receipt: Receipt):
+async def receipt_analyze(file: UploadFile = File(...)):
     """
     レシートの合計を返す
     """
-    total = analyze.main(receipt.file)
+    total = analyze.main(file.file.read())
     return {"total": total}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "pytesseract>=0.3.13",
     "fastapi>=0.114.0",
     "uvicorn[standard]>=0.30.6",
+    "python-multipart>=0.0.9",
 ]
 readme = "README.md"
 requires-python = ">= 3.11"

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -72,6 +72,8 @@ pytesseract==0.3.13
 pytest==8.3.2
 python-dotenv==1.0.1
     # via uvicorn
+python-multipart==0.0.9
+    # via receipt-scanner-model
 pyyaml==6.0.2
     # via pre-commit
     # via uvicorn

--- a/requirements.lock
+++ b/requirements.lock
@@ -42,6 +42,8 @@ pytesseract==0.3.13
     # via receipt-scanner-model
 python-dotenv==1.0.1
     # via uvicorn
+python-multipart==0.0.9
+    # via receipt-scanner-model
 pyyaml==6.0.2
     # via uvicorn
 sniffio==1.3.1

--- a/src/receipt_scanner_model/analyze.py
+++ b/src/receipt_scanner_model/analyze.py
@@ -6,15 +6,16 @@ import numpy as np
 import pytesseract
 import re
 
+from io import BytesIO
 
 LANG = "eng+jpn"
 
 
-def preprocessing(image_path: str) -> Image.Image:
+def preprocessing(image_bytes: bytes) -> Image.Image:
     """
     画像の前処理を行う
     """
-    img = Image.open(image_path)
+    img = Image.open(BytesIO(image_bytes))
     img = img.convert("L")
     img = ImageEnhance.Contrast(img).enhance(2)
 
@@ -119,13 +120,13 @@ def get_total(text: str) -> int:
     return get_most_likely(kws_dict, totals)
 
 
-def scan(fp: str) -> int:
+def scan(image_bytes: bytes) -> int:
     """
     レシートから最もらしい合計金額を出力する
     """
 
     # 画像の前処理
-    preprocessed_image = preprocessing(fp)
+    preprocessed_image = preprocessing(image_bytes)
 
     # textデータに変換
     text = get_text(preprocessed_image)
@@ -137,10 +138,9 @@ def scan(fp: str) -> int:
 
 
 # NOTE: ファイル名などをコマンドラインから取れるようにする。
-# TODO: 画像データはbytesで渡す形にする。
-def main(fp: str) -> str:
+def main(image_bytes: bytes) -> int:
     """
     実行するmain関数
     """
-    # total = scan(fp=fp)
-    return fp
+    total = scan(image_bytes=image_bytes)
+    return total

--- a/tests/test_api/test_main.py
+++ b/tests/test_api/test_main.py
@@ -4,6 +4,8 @@ from api.main import app
 
 client = TestClient(app)
 
+TEST_IMAGE_PATH = "/Users/ayumu/my-projects/receipt-scanner-model/raw/ok.jpeg"
+
 
 def test_root():
     """
@@ -20,11 +22,7 @@ def test_post_receipt_analyze():
     """
     response = client.post(
         "/receipt-analyze",
-        json={
-            "file": "/Users/ayumu/my-projects/receipt-scanner-model/raw/book-off.jpeg"
-        },
+        files={"file": open(TEST_IMAGE_PATH, "rb")},
     )
     assert response.status_code == 200
-    assert response.json() == {
-        "total": "/Users/ayumu/my-projects/receipt-scanner-model/raw/book-off.jpeg"
-    }
+    assert response.json() == {"total": 1125}

--- a/tests/test_src/test_analyze.py
+++ b/tests/test_src/test_analyze.py
@@ -1,5 +1,14 @@
 from src.receipt_scanner_model import analyze
+from PIL import Image
+import io
+
+
+TEST_IMAGE_PATH = "/Users/ayumu/my-projects/receipt-scanner-model/raw/ok.jpeg"
 
 
 def test_main():
-    assert isinstance(analyze.main("file_path_test"), str)
+    image = Image.open(TEST_IMAGE_PATH)
+    img_bytes = io.BytesIO()
+    image.save(img_bytes, format="JPEG")
+    img_bytes = img_bytes.getvalue()
+    assert isinstance(analyze.main(img_bytes), int)


### PR DESCRIPTION
## 概要
レシートを解析する機能を引数をbytesに変更した

## 実装詳細
- apiで引数にファイルを追加できるように、Formをインストールした
  - [➕ Formをするためにpython-multipartをインストールした (](https://github.com/AyumuOgasawara/receipt-scanner-model/commit/00db317289e635e8b6013088819335beb62c8a17)https://github.com/AyumuOgasawara/receipt-scanner-model/issues/16[)](https://github.com/AyumuOgasawara/receipt-scanner-model/commit/00db317289e635e8b6013088819335beb62c8a17)
-  `src/receipt_scanner_model/analyze.py`の引数を`bytes`にした
  - [✨ レシートを解析する機能の引数をbytesにした (](https://github.com/AyumuOgasawara/receipt-scanner-model/commit/33edee38987823b5ad44b0af66864ac8247c87f6)https://github.com/AyumuOgasawara/receipt-scanner-model/issues/16[)](https://github.com/AyumuOgasawara/receipt-scanner-model/commit/33edee38987823b5ad44b0af66864ac8247c87f6)
  - apiの引数をbytesに変更した
    - [👽️ receipt_analyzeの引数をFileにした (](https://github.com/AyumuOgasawara/receipt-scanner-model/commit/bdb0ac009e588b002fca5fddfab880639bb64c8a)https://github.com/AyumuOgasawara/receipt-scanner-model/issues/16[)](https://github.com/AyumuOgasawara/receipt-scanner-model/commit/bdb0ac009e588b002fca5fddfab880639bb64c8a)
- 上記の変更に対してtestを実行した 
  - [✅ bytesを引数にした場合のテストを実行した (](https://github.com/AyumuOgasawara/receipt-scanner-model/commit/8c7fa9120d377a2abf83eb32795c83e8a9b88f52)https://github.com/AyumuOgasawara/receipt-scanner-model/issues/16[)](https://github.com/AyumuOgasawara/receipt-scanner-model/commit/8c7fa9120d377a2abf83eb32795c83e8a9b88f52)

## 関連タスク
Closes #16 

## 動作確認
テスト
<img width="1056" alt="スクリーンショット 2024-09-10 20 50 20" src="https://github.com/user-attachments/assets/9b954ce1-28f1-4422-bf95-d42383c24682">
