### PR TITLE
✨ Structured Outputsを使用して、GPTからの決まった型を返すようにし、解析結果をReceiptDetailで返すようにした (#27)

### DIFF
--- a/src/receipt_scanner_model/main.py
+++ b/src/receipt_scanner_model/main.py
@@ -9,7 +9,7 @@ class ReceiptDetail(TypedDict):
     category: str | None
 
 
-IMAGE = "/Users/ayumu/my-projects/receipt-scanner-model/raw/IMG_9159.JPG"
+IMAGE = "/Users/ayumu/my-projects/receipt-scanner-model/raw/sake.jpeg"
 SYSTEM_PROMPT = """
 あなたはレシートのテキストから家計簿をつけるロボットです。
 与えられるデータはレシートをOCRしたテキストデータです。
@@ -21,7 +21,7 @@ SYSTEM_PROMPT = """
 取得できない場合は None としてください。
 
 ## store_name
-取得した店名を取得してください。
+取得した店名を取得してください。不自然なスペースがある際はスペースを削除してください。
 上に記載されることが多いです。取得できない場合は None としてください。
 
 ## date
@@ -56,6 +56,3 @@ def get_receipt_detail(image: str) -> ReceiptDetail:
         }
     else:
         return {"store_name": None, "amount": 0, "date": None, "category": None}
-
-
-print(get_receipt_detail(IMAGE))


### PR DESCRIPTION
## 概要
[Structured Outputs](https://platform.openai.com/docs/guides/structured-outputs/structured-outputs)を使用して、GPTから返ってくる型を定義した。
その後、GPTから返ってきた`カテゴリー`、`店名`、`金額`と、正規表現をして取得した`金額`を合わせて、ReceiptDetail(TypedDict)として、解析結果を返すようにした。
これによって、apiでは、この関数を叩けば、json型となった返り値が取得できる。


## 関連タスク
Closes #27 

## 動作確認
画像データ1
![gindaco](https://github.com/user-attachments/assets/5aefadf0-8fa0-4410-9477-da7ca36afe60)

結果
``` sh
{'store_name': 'GINDACO', 'amount': 626, 'date': '2024/07/14', 'category': '食費'}
```

画像データ2
![sake](https://github.com/user-attachments/assets/368d0d62-d73e-46dc-9a1a-936e88aff3b9)

結果
``` sh
{'store_name': '浅野日本酒店 HAMAMATSUCHO', 'amount': 800, 'date': '2024/07/11', 'category': '食費'}
```