### PR TITLE
♻️ レシートから合計金額を取得する実装のリファクタリング

### DIFF
--- a/src/receipt_scanner_model/analyze.py
+++ b/src/receipt_scanner_model/analyze.py
@@ -72,14 +72,20 @@ def get_most_likely(
     if n_unique_totals == 1:
         return all_totals[0]
 
+    high_potential_totals = []
+
     for predictive_keyword in ["合計", "paypay", "クレジット"]:
         predictions = kws_amount_dict.get(predictive_keyword)
         if predictions:
             n_unique_predictions = len(set(predictions))
             if n_unique_predictions == 1:
-                return predictions[0]
+                high_potential_totals.append(predictions[0])
             else:
-                return max(predictions)
+                high_potential_totals.append(max(predictions))
+
+    if high_potential_totals:
+        return max(high_potential_totals)
+
     return dict_max(count_amount_dict)
 
 
@@ -87,8 +93,9 @@ def dict_max(count_amount_dict: dict[int, int]) -> int:
     """
     合計金額となり得るものを数字の個数や、大きさから判断する
     """
-    max_count_value = max(count_amount_dict.values())
-    max_counts_list = [k for k, v in count_amount_dict.items() if v == max_count_value]
+    max_counts_list = [
+        k for k, v in count_amount_dict.items() if v == max(count_amount_dict.values())
+    ]
     dict_len = len(max_counts_list)
     match dict_len:
         case 0:

--- a/src/receipt_scanner_model/analyze.py
+++ b/src/receipt_scanner_model/analyze.py
@@ -59,9 +59,8 @@ def clean_text_line(line):
     return line.replace(" ", "").lower()
 
 
-# NOTE: dictは型定義をTypedDictとかで行う。
 def get_most_likely(
-    kws_amount_dict: dict[str, list[int]], count_amount_dict: dict
+    kws_amount_dict: dict[str, list[int]], count_amount_dict: dict[int, int]
 ) -> int:
     """
     合計金額の可能性がある数字を返す
@@ -84,7 +83,7 @@ def get_most_likely(
     return dict_max(count_amount_dict)
 
 
-def dict_max(count_amount_dict: dict) -> int:
+def dict_max(count_amount_dict: dict[int, int]) -> int:
     """
     合計金額となり得るものを数字の個数や、大きさから判断する
     """
@@ -95,7 +94,7 @@ def dict_max(count_amount_dict: dict) -> int:
         case 0:
             return 0
         case 1:
-            return max_counts_list[0][0]
+            return max_counts_list[0]
         case _:
             return max(max_counts_list)
 

--- a/src/receipt_scanner_model/analyze.py
+++ b/src/receipt_scanner_model/analyze.py
@@ -88,18 +88,16 @@ def dict_max(count_amount_dict: dict) -> int:
     """
     合計金額となり得るものを数字の個数や、大きさから判断する
     """
-    max_counts_dict = [
-        kv
-        for kv in count_amount_dict.items()
-        if kv[1] == max(count_amount_dict.values())
-    ]
-    if len(max_counts_dict) == 1:
-        return max_counts_dict[0][0]
-    else:
-        try:
-            return max([max_counts_dict[i][0] for i in range(len(max_counts_dict))])
-        except Exception:
+    max_count_value = max(count_amount_dict.values())
+    max_counts_list = [k for k, v in count_amount_dict.items() if v == max_count_value]
+    dict_len = len(max_counts_list)
+    match dict_len:
+        case 0:
             return 0
+        case 1:
+            return max_counts_list[0][0]
+        case _:
+            return max(max_counts_list)
 
 
 def extract_total_amount(text: str) -> int:

--- a/src/receipt_scanner_model/analyze.py
+++ b/src/receipt_scanner_model/analyze.py
@@ -18,7 +18,7 @@ class ReceiptAnalyzedData(TypedDict):
     text: str
 
 
-def preprocessing(image_bytes: bytes) -> Image.Image:
+def preprocess_image(image_bytes: bytes) -> Image.Image:
     """
     画像の前処理を行う
     """
@@ -33,14 +33,14 @@ def preprocessing(image_bytes: bytes) -> Image.Image:
     return img
 
 
-def get_text(image: Image.Image) -> str:
+def extract_text_from_image(image: Image.Image) -> str:
     """
     画像データをtextに変換
     """
     return pytesseract.image_to_string(image, lang=LANG)
 
 
-def find_total_from_line(line):
+def extract_amount_from_line(line):
     """
     1行ごとに金額を取得
     """
@@ -52,7 +52,7 @@ def find_total_from_line(line):
         return int(re.sub(r"[^\d]", "", numbers[-1]))
 
 
-def clean_line(line):
+def clean_text_line(line):
     """
     空白を削除し行を整える
     """
@@ -60,33 +60,39 @@ def clean_line(line):
 
 
 # NOTE: dictは型定義をTypedDictとかで行う。
-def get_most_likely(keywords_dict: dict[str, list[int]], count_dict: dict) -> int:
+def get_most_likely(
+    kws_amount_dict: dict[str, list[int]], count_amount_dict: dict
+) -> int:
     """
     合計金額の可能性がある数字を返す
     """
     all_totals = []
-    for totals_found in keywords_dict.values():
+    for totals_found in kws_amount_dict.values():
         all_totals += totals_found
     n_unique_totals = len(set(all_totals))
     if n_unique_totals == 1:
         return all_totals[0]
 
     for predictive_keyword in ["合計", "paypay", "クレジット"]:
-        predictions = keywords_dict.get(predictive_keyword)
+        predictions = kws_amount_dict.get(predictive_keyword)
         if predictions:
             n_unique_predictions = len(set(predictions))
             if n_unique_predictions == 1:
                 return predictions[0]
             else:
                 return max(predictions)
-    return dict_max(count_dict)
+    return dict_max(count_amount_dict)
 
 
-def dict_max(dict: dict) -> int:
+def dict_max(count_amount_dict: dict) -> int:
     """
     合計金額となり得るものを数字の個数や、大きさから判断する
     """
-    max_counts_dict = [kv for kv in dict.items() if kv[1] == max(dict.values())]
+    max_counts_dict = [
+        kv
+        for kv in count_amount_dict.items()
+        if kv[1] == max(count_amount_dict.values())
+    ]
     if len(max_counts_dict) == 1:
         return max_counts_dict[0][0]
     else:
@@ -96,7 +102,7 @@ def dict_max(dict: dict) -> int:
             return 0
 
 
-def get_total(text: str) -> int:
+def extract_total_amount(text: str) -> int:
     """
     レシートのテキストデータから合計を取得する
     """
@@ -106,15 +112,15 @@ def get_total(text: str) -> int:
     # 商品の点数など、取得したくないものを illegal_keywords に入れる
     illegal_keywords = ["点数", "お釣り"]
 
-    kws_dict = {word: [] for word in keywords}
+    kws_amount_dict = {word: [] for word in keywords}
 
     # テキストデータを1行ずつに分け、合計となり得るものを kws_dict に入れていく
     for line in text.splitlines():
-        line_clean = clean_line(line)
+        line_clean = clean_text_line(line)
         found = [word for word in keywords if word in line_clean]
         found_illegal = [word for word in illegal_keywords if word in line_clean]
         if len(found) > 0 and len(found_illegal) == 0:
-            total = find_total_from_line(line_clean)
+            total = extract_amount_from_line(line_clean)
             if total is not None:
                 # totalsに取得したtotalがない場合、追加する
                 if not totals.get(total):
@@ -125,9 +131,9 @@ def get_total(text: str) -> int:
 
                 # kws_dict に totalを追加する
                 for i in found:
-                    kws_dict[i].append(total)
+                    kws_amount_dict[i].append(total)
 
-    return get_most_likely(kws_dict, totals)
+    return get_most_likely(kws_amount_dict, totals)
 
 
 def scan(image_bytes: bytes) -> ReceiptAnalyzedData:
@@ -136,18 +142,17 @@ def scan(image_bytes: bytes) -> ReceiptAnalyzedData:
     """
 
     # 画像の前処理
-    preprocessed_image = preprocessing(image_bytes)
+    preprocessed_image = preprocess_image(image_bytes)
 
     # textデータに変換
-    text = get_text(preprocessed_image)
+    text = extract_text_from_image(preprocessed_image)
 
     # レシートから合計を取得
-    total = get_total(text)
+    total = extract_total_amount(text)
 
     return {"amount": total, "text": text}
 
 
-# NOTE: ファイル名などをコマンドラインから取れるようにする。
 def main(image_bytes: bytes) -> ReceiptAnalyzedData:
     """
     実行するmain関数

--- a/tests/test_src/test_analyze.py
+++ b/tests/test_src/test_analyze.py
@@ -11,4 +11,36 @@ def test_main():
     img_bytes = io.BytesIO()
     image.save(img_bytes, format="JPEG")
     img_bytes = img_bytes.getvalue()
-    assert isinstance(analyze.main(img_bytes)["amount"], int)
+    expected = 1125
+    actual = analyze.main(img_bytes)["amount"]
+    assert expected == actual
+
+
+def test_dict_max_empty():
+    amount_dict = {}
+    expected = 0
+    actual = analyze.dict_max(amount_dict)
+    assert expected == actual
+
+
+def test_dict_max():
+    amount_dict = {1042: 1, 1: 1, 1125: 2}
+    expected = 1125
+    actual = analyze.dict_max(amount_dict)
+    assert expected == actual
+
+
+def test_get_most_likely():
+    kws_amount_dict = {
+        "合計": [1],
+        "小計": [1042],
+        "計": [1042, 1],
+        "言十": [],
+        "paypay": [],
+        "クレジット": [1125],
+        "キャッシュレス": [],
+    }
+    count_amount_dict = {1042: 2, 1: 2, 1125: 1}
+    expected = 1125
+    actual = analyze.get_most_likely(kws_amount_dict, count_amount_dict)
+    assert expected == actual


### PR DESCRIPTION
## 概要
レシートから合計金額を取得する実装(analyze.py)のリファクタリング

## 実装詳細
以下のリファクタリングを行った。
- わかりにくい名前の変数名・関数名を変更した
  - [♻️ 変数を変更 (#33)](https://github.com/AyumuOgasawara/receipt-scanner-model/commit/979cc8461432d15557466fa90dd138e5e6e68439)
- エラーを挙げて、エラーハンドリングしていた場所をエラーを挙げずに対応するようにした
  - [♻️ エラーハンドリングをしていた部分をエラーがあがらないようにし、対応した (#33)](https://github.com/AyumuOgasawara/receipt-scanner-model/commit/208811f1b518dd4a3ffe314d9dac6bc57fb9906c)
- [♻️ dictと曖昧だった方を型付けしそれに伴う修正をした (#33)](https://github.com/AyumuOgasawara/receipt-scanner-model/commit/29f8bea14fc701d2f83900ce1187be075c3df205)
- 今まで、「"合計"、"paypay"、"クレジット"」で取得されるものが複数あり、違う値である場合を考慮した実装ができていなかったため、high_potential_totalsにまず代入し、その後、最大値を選ぶようにした。
  - [⚡️ high_potential_totalsが複数ある際にその中からのマックスを取得するようにした (#33, #34)](https://github.com/AyumuOgasawara/receipt-scanner-model/commit/0a5eae82ef004633fbbb175c203118cd8205fa29)
- [✅ 変更した関数に対してテストを行った (#33)](https://github.com/AyumuOgasawara/receipt-scanner-model/commit/1504d6aa3c63261d1ee99005ef0ad055c60404c3)

## 動作確認
- テストに全て通り、思っていた挙動を確認できた。

## 関連イシュー
Closes #33  