### PR TITLE
✅ レシートの詳細を返す関数のテストを作成した (#20)

### DIFF
--- a/tests/test_api/test_main.py
+++ b/tests/test_api/test_main.py
@@ -1,10 +1,16 @@
+import os
 from fastapi.testclient import TestClient
 
 from api.main import app
 
 client = TestClient(app)
 
-TEST_IMAGE_PATH = "/Users/ayumu/my-projects/receipt-scanner-model/raw/ok.jpeg"
+
+# 現在のスクリプトのディレクトリを取得
+current_dir = os.path.dirname(os.path.abspath(__file__))
+
+# 相対パスで画像ファイルを指定
+TEST_IMAGE_PATH = os.path.join(current_dir, "../../raw/ok.jpeg")
 
 
 def test_root():

--- a/tests/test_api/test_main.py
+++ b/tests/test_api/test_main.py
@@ -24,7 +24,7 @@ def test_root():
 
 def test_post_receipt_analyze():
     """
-    レシートのfpを確認するテスト
+    レシートの合計金額を取得するテスト
     """
     response = client.post(
         "/scan-receipt",

--- a/tests/test_src/test_analyze.py
+++ b/tests/test_src/test_analyze.py
@@ -1,0 +1,26 @@
+import os
+from src.receipt_scanner_model import analyze
+from PIL import Image
+import io
+
+# 現在のスクリプトのディレクトリを取得
+current_dir = os.path.dirname(os.path.abspath(__file__))
+
+# 相対パスで画像ファイルを指定
+TEST_IMAGE_PATH = os.path.join(current_dir, "../../raw/book-off.png")
+
+
+def test_get_receipt_detail():
+    """レシートの詳細を取得する関数のテスト"""
+    image = Image.open(TEST_IMAGE_PATH)
+    img_bytes = io.BytesIO()
+    image.save(img_bytes, format="JPEG")
+    img_bytes = img_bytes.getvalue()
+    expected = {
+        "store_name": "BOOKOFF 秋葉原駅前店",
+        "amount": 990,
+        "date": "2024/07/18",
+        "category": "娯楽",
+    }
+    actual = analyze.get_receipt_detail(img_bytes)
+    assert expected == actual

--- a/tests/test_src/test_scan_receipt.py
+++ b/tests/test_src/test_scan_receipt.py
@@ -1,9 +1,13 @@
+import os
 from src.receipt_scanner_model import scan_receipt
 from PIL import Image
 import io
 
+# 現在のスクリプトのディレクトリを取得
+current_dir = os.path.dirname(os.path.abspath(__file__))
 
-TEST_IMAGE_PATH = "/Users/ayumu/my-projects/receipt-scanner-model/raw/ok.jpeg"
+# 相対パスで画像ファイルを指定
+TEST_IMAGE_PATH = os.path.join(current_dir, "../../raw/ok.jpeg")
 
 
 def test_main():

--- a/tests/test_src/test_scan_receipt.py
+++ b/tests/test_src/test_scan_receipt.py
@@ -11,6 +11,9 @@ TEST_IMAGE_PATH = os.path.join(current_dir, "../../raw/ok.jpeg")
 
 
 def test_main():
+    """
+    レシートの合計金額を取得する関数のテスト
+    """
     image = Image.open(TEST_IMAGE_PATH)
     img_bytes = io.BytesIO()
     image.save(img_bytes, format="JPEG")
@@ -21,6 +24,9 @@ def test_main():
 
 
 def test_dict_max_empty():
+    """
+    amount_dictが{}の場合のdict_max関数のテスト
+    """
     amount_dict = {}
     expected = 0
     actual = scan_receipt.dict_max(amount_dict)
@@ -28,6 +34,9 @@ def test_dict_max_empty():
 
 
 def test_dict_max():
+    """
+    dict_max関数のテスト
+    """
     amount_dict = {1042: 1, 1: 1, 1125: 2}
     expected = 1125
     actual = scan_receipt.dict_max(amount_dict)
@@ -35,6 +44,9 @@ def test_dict_max():
 
 
 def test_get_most_likely():
+    """
+    get_most_likely関数のテスト
+    """
     kws_amount_dict = {
         "合計": [1],
         "小計": [1042],


### PR DESCRIPTION
## 概要
レシートの画像を渡して期待した詳細結果が返ってくるかのテストを行った。

このイシューで、以下の点も修正した。
- TEAT_IMAGE_PATHを環境に依存しないようにした
- 各テストに何のテストなのかをdocstringで書くようにした。

## 動作確認
pytestを実行し、全てパスした

<img width="974" alt="スクリーンショット 2024-11-27 5 22 16" src="https://github.com/user-attachments/assets/4646d8fb-43b8-47d7-9978-9c2113632237">


## 関連タスク
Closes #20