### PR TITLE
loggingを設定し、ログの出力が行えるようにした (#51)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ output/
 
 ## env
 .env
+
+## logs
+logs/

--- a/api/main.py
+++ b/api/main.py
@@ -28,7 +28,7 @@ class FileName(BaseModel):
     filename: str
 
 
-def handle_receipt_exception(e: Exception):
+def handle_receipt_exception(e: Exception, filename: str | None):
     """例外を分類してHTTPExceptionに変換する
 
     Args:
@@ -38,7 +38,7 @@ def handle_receipt_exception(e: Exception):
         HTTPException: 適切なステータスコードとメッセージを持つHTTPException
     """
     logger = logging.getLogger(__name__)
-    logger.exception("レシート解析中にエラーが起きました。")
+    logger.exception(f"レシート解析中にエラーが起きました。ファイル名: {filename}")
 
     if isinstance(e, (S3BadRequest, S3NotFound)):
         return HTTPException(
@@ -80,7 +80,9 @@ def receipt_analyze(request: FileName) -> ReceiptDetail:
     Returns:
         ReceiptDetail: 解析したレシート詳細
     """
+    filename = None
     try:
+        filename = request.filename
         # S3Clientを初期化
         s3_client = S3Client()
 
@@ -90,4 +92,4 @@ def receipt_analyze(request: FileName) -> ReceiptDetail:
         receipt_detail = get_receipt_detail(image_bytes)
         return receipt_detail
     except Exception as e:
-        raise handle_receipt_exception(e)
+        raise handle_receipt_exception(e, filename)

--- a/api/main.py
+++ b/api/main.py
@@ -1,7 +1,9 @@
 from fastapi import FastAPI, HTTPException
 from src.receipt_scanner_model.analyze import ReceiptDetail, get_receipt_detail
 from src.receipt_scanner_model.s3_client import S3Client
+from src.receipt_scanner_model.logger_config import set_logger
 import tomllib
+import logging
 from pydantic import BaseModel
 from src.receipt_scanner_model.error import (
     S3BadRequest,
@@ -10,6 +12,10 @@ from src.receipt_scanner_model.error import (
     S3ServiceUnavailable,
     S3InternalServiceError,
 )
+
+# ログ設定を初期化
+set_logger()
+logger = logging.getLogger(__name__)
 
 with open("pyproject.toml", "rb") as f:
     data = tomllib.load(f)
@@ -22,6 +28,40 @@ class FileName(BaseModel):
     filename: str
 
 
+def handle_receipt_exception(e: Exception):
+    """例外を分類してHTTPExceptionに変換する
+
+    Args:
+        e: キャッチされた例外
+
+    Returns:
+        HTTPException: 適切なステータスコードとメッセージを持つHTTPException
+    """
+    logger = logging.getLogger(__name__)
+    logger.exception("レシート解析中にエラーが起きました。")
+
+    if isinstance(e, (S3BadRequest, S3NotFound)):
+        return HTTPException(
+            status_code=400,
+            detail="レシート解析中にエラーが起きました。再度レシートをアップロードしてください。",
+        )
+    elif isinstance(e, S3ServiceUnavailable):
+        return HTTPException(
+            status_code=503,
+            detail="レシート解析中にエラーが起きました。しばらくしてから再度お試しください。",
+        )
+    elif isinstance(e, (S3Forbidden, S3InternalServiceError)):
+        return HTTPException(
+            status_code=500,
+            detail="レシート解析中にエラーが起きました。開発者にお問い合わせください。",
+        )
+    else:
+        return HTTPException(
+            status_code=500,
+            detail="レシート解析中にエラーが起きました。開発者にお問い合わせください。",
+        )
+
+
 @app.get("/")
 async def root():
     """
@@ -31,7 +71,7 @@ async def root():
 
 
 @app.post("/receipt-analyze")
-async def receipt_analyze(request: FileName) -> ReceiptDetail:
+def receipt_analyze(request: FileName) -> ReceiptDetail:
     """S3のファイル名からレシートを解析し、ReceiptDetailを返す
 
     Args:
@@ -49,24 +89,5 @@ async def receipt_analyze(request: FileName) -> ReceiptDetail:
 
         receipt_detail = get_receipt_detail(image_bytes)
         return receipt_detail
-    except (S3BadRequest, S3NotFound):
-        raise HTTPException(
-            status_code=400,
-            detail="レシート解析中にエラーが起きました。再度レシートをアップロードしてください。",
-        )
-    except S3ServiceUnavailable:
-        raise HTTPException(
-            status_code=503,
-            detail="レシート解析中にエラーが起きました。しばらくしてから再度お試しください。",
-        )
-    except (S3Forbidden, S3InternalServiceError):
-        raise HTTPException(
-            status_code=500,
-            detail="レシート解析中にエラーが起きました。開発者にお問い合わせください。",
-        )
     except Exception as e:
-        print(f"レシート解析中にエラーが起きました: {e}")
-        raise HTTPException(
-            status_code=500,
-            detail="レシート解析中にエラーが起きました。開発者にお問い合わせください。",
-        )
+        raise handle_receipt_exception(e)

--- a/src/receipt_scanner_model/logger_config.py
+++ b/src/receipt_scanner_model/logger_config.py
@@ -1,0 +1,17 @@
+import logging
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+
+def set_logger() -> None:
+    log_dir = Path("logs/")
+    log_dir.mkdir(parents=True, exist_ok=True)
+    logfile = Path(log_dir, "python_server.log")
+    handler = RotatingFileHandler(logfile, maxBytes=1024 * 1024, backupCount=5)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        datefmt="%Y/%m/%d %H:%M:%S",
+        handlers=[handler],
+    )

--- a/src/receipt_scanner_model/s3_client.py
+++ b/src/receipt_scanner_model/s3_client.py
@@ -2,6 +2,7 @@
 
 import boto3
 import io
+import logging
 from src.receipt_scanner_model.setting import setting
 from botocore.exceptions import ClientError
 from src.receipt_scanner_model.error import (
@@ -11,6 +12,8 @@ from src.receipt_scanner_model.error import (
     S3ServiceUnavailable,
     S3InternalServiceError,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class S3Client:
@@ -56,33 +59,47 @@ class S3Client:
             )
 
             if http_status_code == 400:
-                print(f"{http_status_code}: {error_message}")
+                logger.error(
+                    f"ダウンロード中にエラーが起きました: {http_status_code} {error_message}"
+                )
                 raise S3BadRequest(
                     http_status_code,
                     f"ダウンロード中にエラーが起きました: {error_message}",
                 )
             elif http_status_code == 404:
-                print(f"{http_status_code}: {error_message}")
+                logger.error(
+                    f"ダウンロード中にエラーが起きました: {http_status_code} {error_message}"
+                )
                 raise S3NotFound(
                     http_status_code,
                     f"ダウンロード中にエラーが起きました: {error_message}",
                 )
             elif http_status_code == 403:
+                logger.error(
+                    f"アクセスが拒否されました: {http_status_code} {error_message}"
+                )
                 raise S3Forbidden(
                     http_status_code,
                     f"アクセスが拒否されました: {error_message}",
                 )
             elif http_status_code == 503:
+                logger.error(
+                    f"ダウンロード中に予期しないエラーが発生しました: {http_status_code} {error_message}"
+                )
                 raise S3ServiceUnavailable(
                     http_status_code,
                     f"ダウンロード中に予期しないエラーが発生しました: {error_message}",
                 )
             else:
+                logger.error(
+                    f"ダウンロード中に予期しないエラーが発生しました: {http_status_code} {error_message}"
+                )
                 raise S3InternalServiceError(
                     http_status_code,
                     f"ダウンロード中に予期しないエラーが発生しました: {error_message}",
                 )
         except Exception as e:
+            logger.error(f"ダウンロード中に予期しないエラーが発生しました: {e}")
             raise S3InternalServiceError(
                 500, f"ダウンロード中に予期しないエラーが発生しました: {e}"
             )


### PR DESCRIPTION
## 概要
以下のようにloggingの設定を行い、ログファイルが出力されるようにした
- RotatingFileHandlerを使用
  - maxBytes=1024 * 1024
  - backupCount=5
- logs/python_server.logに出力
- エラー時には、logger.exceptionを使って、trace bacckが確認できるようにした。また、ファイル名を出力に含めるようにした。

## 補足
logger.exceptionを使うにあたって、`receipt-analyze`apiのエラーハンドリングをまとめている。

## 動作確認
各エラーを発生させ、ログが出力されるか確認した。

Closes #51 