### PR TITLE
🧑‍💻 .claude/settingの更新 (#68)

### DIFF
--- a/.claude/setting.json
+++ b/.claude/setting.json
@@ -1,10 +1,31 @@
 {
-    "permissions": {
-      "allow": [
-      ],
-      "deny": [
-        "Read(.env*)",
-        "Write(.env*)"
-      ]
-    }
+  "permissions": {
+    "allow": [
+    ],
+    "deny": [
+      "Bash(sudo:*)",
+      "Bash(rm:*)",
+      "Bash(rm -rf:*)",
+      "Bash(git push:*)",
+      "Bash(git commit:*)",
+      "Bash(git reset:*)",
+      "Bash(git rebase:*)",
+      "Read(.env.*)",
+      "Read(id_rsa)",
+      "Read(id_ed25519)",
+      "Read(**/*token*)",
+      "Read(**/*key*)",
+      "Write(.env*)",
+      "Write(**/secrets/**)",
+      "Bash(curl:*)",
+      "Bash(wget:*)",
+      "Bash(nc:*)",
+      "Bash(npm uninstall:*)",
+      "Bash(npm remove:*)",
+      "Bash(psql:*)",
+      "Bash(mysql:*)",
+      "Bash(mongod:*)",
+      "mcp__supabase__execute_sql"
+    ]
   }
+}

--- a/.claude/setting.json
+++ b/.claude/setting.json
@@ -25,7 +25,11 @@
       "Bash(psql:*)",
       "Bash(mysql:*)",
       "Bash(mongod:*)",
-      "mcp__supabase__execute_sql"
+      "mcp__supabase__execute_sql",
+      "Bash(docker:*)",
+      "Bash(systemctl:*)",
+      "Bash(chmod:*)",
+      "Write(**/config/**)"
     ]
   }
 }


### PR DESCRIPTION
## 概要

.claude/settingを更新し、より安全にClaude Codeを使用できるようにした。

## 動作確認
`claude 禁止コマンド`でPermission エラーが出ることを確認

例)
``` sh
Error: Permission to use Bash with command git push origin main has been denied.
```

Closes #68 