### PR TITLE
✅ レシート画像解析時のテストを追加 (#65)

### DIFF
--- a/src/receipt_scanner_model/open_ai.py
+++ b/src/receipt_scanner_model/open_ai.py
@@ -87,9 +87,12 @@ class OpenAIHandler:
     MODEL = "gpt-4o-mini"
     TEMPERATURE = 0
     MAX_TOKENS = 16384
+    MAX_RETRIES = 3
 
     def __init__(self):
-        self.client = OpenAI(api_key=setting.openai_api_key, max_retries=3)
+        self.client = OpenAI(
+            api_key=setting.openai_api_key, max_retries=OpenAIHandler.MAX_RETRIES
+        )
 
     @openai_error_handling
     def analyze_image(self, base64_image: str):

--- a/tests/test_src/test_analyze.py
+++ b/tests/test_src/test_analyze.py
@@ -9,14 +9,12 @@ from src.receipt_scanner_model.error import (
 )
 from src.receipt_scanner_model.analyze import get_receipt_detail
 
-# セキュアなテスト用データ
 TEST_IMAGE_BYTES = b"MockImageBytesForTesting"
 TEST_BASE64_IMAGE = "data:image/png;base64,MockImageDataForTesting"
 
 
 @pytest.fixture
 def test_receipt_detail() -> ReceiptDetail:
-    """テスト用のReceiptDetailフィクスチャ"""
     return ReceiptDetail(
         store_name="Test Store",
         date="2023/10/01",
@@ -27,7 +25,6 @@ def test_receipt_detail() -> ReceiptDetail:
 
 @pytest.fixture
 def mock_encode_image(mocker: MockFixture):
-    """encode_image関数のモック"""
     return mocker.patch(
         "src.receipt_scanner_model.analyze.encode_image",
         return_value=TEST_BASE64_IMAGE,
@@ -36,7 +33,6 @@ def mock_encode_image(mocker: MockFixture):
 
 @pytest.fixture
 def mock_openai_handler(mocker: MockFixture):
-    """OpenAIHandlerのモック"""
     return mocker.patch("src.receipt_scanner_model.analyze.OpenAIHandler").return_value
 
 
@@ -48,7 +44,6 @@ def test_get_receipt_detail_success(
 
     result = get_receipt_detail(TEST_IMAGE_BYTES)
 
-    # 結果の検証
     assert result.store_name == test_receipt_detail.store_name
     assert result.date == test_receipt_detail.date
     assert result.amount == test_receipt_detail.amount
@@ -86,7 +81,6 @@ def test_get_receipt_detail_error_handling(
     status_code,
     expected_message,
 ):
-    """get_receipt_detailのエラーハンドリングをテスト"""
     mock_openai_handler.analyze_image.side_effect = exception(
         status_code, expected_message
     )

--- a/tests/test_src/test_analyze.py
+++ b/tests/test_src/test_analyze.py
@@ -1,26 +1,98 @@
-import os
-from src.receipt_scanner_model import analyze
-from PIL import Image
-import io
+from pytest_mock import MockFixture
+import pytest
+from src.receipt_scanner_model.open_ai import ReceiptDetail
+from src.receipt_scanner_model.error import (
+    OpenAIAuthenticationError,
+    OpenAIServiceUnavailable,
+    OpenAIUnexpectedError,
+    OpenAIResponseFormatError,
+)
+from src.receipt_scanner_model.analyze import get_receipt_detail
 
-# 現在のスクリプトのディレクトリを取得
-current_dir = os.path.dirname(os.path.abspath(__file__))
-
-# 相対パスで画像ファイルを指定
-TEST_IMAGE_PATH = os.path.join(current_dir, "../../raw/book-off.png")
+# セキュアなテスト用データ
+TEST_IMAGE_BYTES = b"MockImageBytesForTesting"
+TEST_BASE64_IMAGE = "data:image/png;base64,MockImageDataForTesting"
 
 
-def test_get_receipt_detail():
-    """レシートの詳細を取得する関数のテスト"""
-    image = Image.open(TEST_IMAGE_PATH)
-    img_bytes = io.BytesIO()
-    image.save(img_bytes, format="JPEG")
-    img_bytes = img_bytes.getvalue()
-    expected = {
-        "store_name": "BOOKOFF 秋葉原駅前店",
-        "amount": 990,
-        "date": "2024/07/18",
-        "category": "娯楽",
-    }
-    actual = analyze.get_receipt_detail(img_bytes)
-    assert expected == actual
+@pytest.fixture
+def test_receipt_detail() -> ReceiptDetail:
+    """テスト用のReceiptDetailフィクスチャ"""
+    return ReceiptDetail(
+        store_name="Test Store",
+        date="2023/10/01",
+        amount=1500,
+        category="食費",
+    )
+
+
+@pytest.fixture
+def mock_encode_image(mocker: MockFixture):
+    """encode_image関数のモック"""
+    return mocker.patch(
+        "src.receipt_scanner_model.analyze.encode_image",
+        return_value=TEST_BASE64_IMAGE,
+    )
+
+
+@pytest.fixture
+def mock_openai_handler(mocker: MockFixture):
+    """OpenAIHandlerのモック"""
+    return mocker.patch("src.receipt_scanner_model.analyze.OpenAIHandler").return_value
+
+
+def test_get_receipt_detail_success(
+    mock_openai_handler,
+    test_receipt_detail: ReceiptDetail,
+):
+    mock_openai_handler.analyze_image.return_value = test_receipt_detail
+
+    result = get_receipt_detail(TEST_IMAGE_BYTES)
+
+    # 結果の検証
+    assert result.store_name == test_receipt_detail.store_name
+    assert result.date == test_receipt_detail.date
+    assert result.amount == test_receipt_detail.amount
+    assert result.category == test_receipt_detail.category
+
+
+@pytest.mark.parametrize(
+    "exception, status_code, expected_message",
+    [
+        (
+            OpenAIAuthenticationError,
+            401,
+            "OpenAIの認証に失敗しました。APIキーを確認してください。",
+        ),
+        (
+            OpenAIServiceUnavailable,
+            503,
+            "OpenAIのサービスが一時的に利用できません。時間をおいて再度お試しください。",
+        ),
+        (
+            OpenAIUnexpectedError,
+            500,
+            "OpenAIの予期しないエラーが発生しました。",
+        ),
+        (
+            OpenAIResponseFormatError,
+            503,
+            "OpenAIの応答の解析に失敗しました。",
+        ),
+    ],
+)
+def test_get_receipt_detail_error_handling(
+    mock_openai_handler,
+    exception,
+    status_code,
+    expected_message,
+):
+    """get_receipt_detailのエラーハンドリングをテスト"""
+    mock_openai_handler.analyze_image.side_effect = exception(
+        status_code, expected_message
+    )
+
+    with pytest.raises(exception) as exc_info:
+        get_receipt_detail(TEST_IMAGE_BYTES)
+
+    assert exc_info.value.code == status_code
+    assert exc_info.value.message == expected_message

--- a/tests/test_src/test_openai.py
+++ b/tests/test_src/test_openai.py
@@ -1,0 +1,189 @@
+from pytest_mock import MockFixture
+import pytest
+from src.receipt_scanner_model.open_ai import OpenAIHandler, ReceiptDetail
+from src.receipt_scanner_model.error import (
+    OpenAIAuthenticationError,
+    OpenAIServiceUnavailable,
+    OpenAIUnexpectedError,
+    OpenAIResponseFormatError,
+)
+from openai.types.chat.parsed_chat_completion import (
+    ParsedChatCompletion,
+    ParsedChoice,
+    ParsedChatCompletionMessage,
+)
+from openai import (
+    APITimeoutError,
+    PermissionDeniedError,
+    InternalServerError,
+    RateLimitError,
+    AuthenticationError,
+)
+
+# セキュアなテスト用Base64データ
+TEST_BASE64_IMAGE = "data:image/png;base64,MockImageDataForTesting"
+
+
+def create_mock_completion(parsed_data=None):
+    return ParsedChatCompletion[ReceiptDetail](
+        id="chatcmpl-Test1234567890",
+        choices=[
+            ParsedChoice[ReceiptDetail](
+                finish_reason="stop",
+                index=0,
+                logprobs=None,
+                message=ParsedChatCompletionMessage[ReceiptDetail](
+                    content=str(parsed_data) if parsed_data else None,
+                    refusal=None,
+                    role="assistant",
+                    annotations=[],
+                    audio=None,
+                    function_call=None,
+                    tool_calls=None,
+                    parsed=parsed_data,
+                ),
+            )
+        ],
+        created=1756420606,
+        model=OpenAIHandler.MODEL,
+        object="chat.completion",
+    )
+
+
+@pytest.fixture
+def test_receipt_detail() -> ReceiptDetail:
+    return ReceiptDetail(
+        store_name="Test Store",
+        date="2023/10/01",
+        amount=1500,
+        category="食費",
+    )
+
+
+@pytest.fixture
+def mock_openai_client(mocker: MockFixture):
+    """OpenAIクライアントのモックを作成するフィクスチャ"""
+    mock_client = mocker.MagicMock()
+    mocker.patch("src.receipt_scanner_model.open_ai.OpenAI", return_value=mock_client)
+    return mock_client
+
+
+@pytest.fixture
+def mock_openai_result(
+    test_receipt_detail: ReceiptDetail,
+) -> ParsedChatCompletion[ReceiptDetail]:
+    return create_mock_completion(test_receipt_detail)
+
+
+def test_analyze_image_success(
+    mock_openai_client,
+    mock_openai_result: ParsedChatCompletion[ReceiptDetail],
+    test_receipt_detail: ReceiptDetail,
+):
+    mock_openai_client.beta.chat.completions.parse.return_value = mock_openai_result
+
+    openai_handler = OpenAIHandler()
+    result = openai_handler.analyze_image(TEST_BASE64_IMAGE)
+
+    assert result.store_name == test_receipt_detail.store_name
+    assert result.date == test_receipt_detail.date
+    assert result.amount == test_receipt_detail.amount
+    assert result.category == test_receipt_detail.category
+
+
+def test_analyze_image_response_format_error(mock_openai_client):
+    mock_completion = create_mock_completion(parsed_data=None)
+    mock_openai_client.beta.chat.completions.parse.return_value = mock_completion
+
+    openai_handler = OpenAIHandler()
+    with pytest.raises(OpenAIResponseFormatError) as exc_info:
+        openai_handler.analyze_image(TEST_BASE64_IMAGE)
+
+    assert exc_info.value.code == 503
+    assert exc_info.value.message == "OpenAIの応答の解析に失敗しました。"
+
+
+def test_openai_handler_initialization():
+    """OpenAIHandler初期化の基本テスト"""
+    handler = OpenAIHandler()
+
+    # 基本的な属性の確認
+    assert handler.client is not None
+    assert handler.client.max_retries == OpenAIHandler.MAX_RETRIES
+    assert handler.MODEL == OpenAIHandler.MODEL
+    assert handler.TEMPERATURE == OpenAIHandler.TEMPERATURE
+    assert handler.MAX_TOKENS == OpenAIHandler.MAX_TOKENS
+
+
+@pytest.mark.parametrize(
+    "exception_type, expected_exception, status_code, expected_message",
+    [
+        (
+            AuthenticationError,
+            OpenAIAuthenticationError,
+            401,
+            "OpenAIの認証に失敗しました。APIキーを確認してください。",
+        ),
+        (
+            PermissionDeniedError,
+            OpenAIAuthenticationError,
+            401,
+            "OpenAIの認証に失敗しました。APIキーを確認してください。",
+        ),
+        (
+            APITimeoutError,
+            OpenAIServiceUnavailable,
+            503,
+            "OpenAIのサービスが一時的に利用できません。時間をおいて再度お試しください。",
+        ),
+        (
+            InternalServerError,
+            OpenAIServiceUnavailable,
+            503,
+            "OpenAIのサービスが一時的に利用できません。時間をおいて再度お試しください。",
+        ),
+        (
+            RateLimitError,
+            OpenAIServiceUnavailable,
+            503,
+            "OpenAIのサービスが一時的に利用できません。時間をおいて再度お試しください。",
+        ),
+        (
+            Exception,
+            OpenAIUnexpectedError,
+            500,
+            "OpenAIの予期しないエラーが発生しました。",
+        ),
+    ],
+)
+def test_analyze_image_error_handling(
+    mocker: MockFixture,
+    mock_openai_client,
+    exception_type,
+    expected_exception,
+    status_code,
+    expected_message,
+) -> None:
+    if exception_type is Exception:
+        mock_openai_client.beta.chat.completions.parse.side_effect = exception_type(
+            "予期せぬエラーが発生しました。"
+        )
+    elif exception_type is APITimeoutError:
+        # APITimeoutErrorは異なる引数構造
+        mock_openai_client.beta.chat.completions.parse.side_effect = exception_type(
+            request=mocker.MagicMock()
+        )
+    else:
+        # その他のOpenAI例外は特定の引数が必要
+        mock_response = mocker.MagicMock()
+        mock_response.status_code = status_code
+        mock_openai_client.beta.chat.completions.parse.side_effect = exception_type(
+            message="OpenAIエラー", response=mock_response, body={}
+        )
+
+    openai_handler = OpenAIHandler()
+    with pytest.raises(expected_exception) as exc_info:
+        openai_handler.analyze_image(TEST_BASE64_IMAGE)
+
+    assert exc_info.value.code == status_code
+    assert exc_info.value.message == expected_message

--- a/tests/test_src/test_openai.py
+++ b/tests/test_src/test_openai.py
@@ -20,7 +20,6 @@ from openai import (
     AuthenticationError,
 )
 
-# セキュアなテスト用Base64データ
 TEST_BASE64_IMAGE = "data:image/png;base64,MockImageDataForTesting"
 
 
@@ -62,7 +61,6 @@ def test_receipt_detail() -> ReceiptDetail:
 
 @pytest.fixture
 def mock_openai_client(mocker: MockFixture):
-    """OpenAIクライアントのモックを作成するフィクスチャ"""
     mock_client = mocker.MagicMock()
     mocker.patch("src.receipt_scanner_model.open_ai.OpenAI", return_value=mock_client)
     return mock_client
@@ -91,6 +89,16 @@ def test_analyze_image_success(
     assert result.category == test_receipt_detail.category
 
 
+def test_openai_handler_initialization():
+    handler = OpenAIHandler()
+
+    assert handler.client is not None
+    assert handler.client.max_retries == OpenAIHandler.MAX_RETRIES
+    assert handler.MODEL == OpenAIHandler.MODEL
+    assert handler.TEMPERATURE == OpenAIHandler.TEMPERATURE
+    assert handler.MAX_TOKENS == OpenAIHandler.MAX_TOKENS
+
+
 def test_analyze_image_response_format_error(mock_openai_client):
     mock_completion = create_mock_completion(parsed_data=None)
     mock_openai_client.beta.chat.completions.parse.return_value = mock_completion
@@ -101,18 +109,6 @@ def test_analyze_image_response_format_error(mock_openai_client):
 
     assert exc_info.value.code == 503
     assert exc_info.value.message == "OpenAIの応答の解析に失敗しました。"
-
-
-def test_openai_handler_initialization():
-    """OpenAIHandler初期化の基本テスト"""
-    handler = OpenAIHandler()
-
-    # 基本的な属性の確認
-    assert handler.client is not None
-    assert handler.client.max_retries == OpenAIHandler.MAX_RETRIES
-    assert handler.MODEL == OpenAIHandler.MODEL
-    assert handler.TEMPERATURE == OpenAIHandler.TEMPERATURE
-    assert handler.MAX_TOKENS == OpenAIHandler.MAX_TOKENS
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## 概要

レシート解析をする以下のファイルのテストを作成
- src/receipt_scanner_model/analyze.py
- src/receipt_scanner_model/open_ai.py

closes #65 

## テストカバレッジ C1


``` sh
Name                                   Stmts   Miss Branch BrPart  Cover   Missing
----------------------------------------------------------------------------------
src/receipt_scanner_model/analyze.py       6      0      0      0   100%
src/receipt_scanner_model/open_ai.py      50      0      2      0   100%
----------------------------------------------------------------------------------
TOTAL                                     56      0      2      0   100%
```

