### PR TITLE
♻️ OpenAIの画像解析で、画像コンテントタイプを直接使用するようにした (#79)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -120,9 +120,10 @@ def receipt_analyze(request: FileName) -> ReceiptDetail:
         s3_client = S3Client()
 
         # S3からファイル名を指定して画像をダウンロード
-        image_bytes, image_type = s3_client.download_image_by_filename(filename)
+        image_bytes, content_type = s3_client.download_image_by_filename(filename)
 
-        receipt_detail = get_receipt_detail(image_bytes, image_type)
+        receipt_detail = get_receipt_detail(image_bytes, content_type)
+        logger.info(receipt_detail)
         return receipt_detail
     except Exception as e:
         raise handle_receipt_exception(e, filename)

--- a/src/receipt_scanner_model/analyze.py
+++ b/src/receipt_scanner_model/analyze.py
@@ -2,16 +2,16 @@ from src.receipt_scanner_model.open_ai import OpenAIHandler, ReceiptDetail
 from src.receipt_scanner_model.file_operations import encode_image
 
 
-def get_receipt_detail(img_bytes: bytes, image_type: str) -> ReceiptDetail:
+def get_receipt_detail(img_bytes: bytes, content_type: str) -> ReceiptDetail:
     """レシートの解析を行い、ReceiptDetailを返す
 
     Args:
         img_bytes (bytes): ダウンロードした画像のバイトデータ
-        image_type (str): 画像のMIMEタイプ（例: "jpeg", "png"）
+        content_type (str): コンテントのMIMEタイプ（例: "image/jpeg", "image/png"）
 
     Returns:
         ReceiptDetail: 店名、金額、日付、カテゴリー
     """
     openai_handler = OpenAIHandler()
     base64_image = encode_image(img_bytes)
-    return openai_handler.analyze_image(base64_image, image_type)
+    return openai_handler.analyze_image(base64_image, content_type)

--- a/src/receipt_scanner_model/open_ai.py
+++ b/src/receipt_scanner_model/open_ai.py
@@ -95,12 +95,12 @@ class OpenAIHandler:
         )
 
     @openai_error_handling
-    def analyze_image(self, base64_image: str, image_type: str) -> ReceiptDetail:
+    def analyze_image(self, base64_image: str, content_type: str) -> ReceiptDetail:
         """OpenAIのAPIを呼び出し、レシートの解析を行う
 
         Args:
             base64_image (str): Base64エンコードされた画像データ
-            image_type (str): 画像のMIMEタイプ（例: "jpeg", "png"）
+            content_type (str): コンテントのMIMEタイプ（例: "image/jpeg", "image/png"）
         Returns:
             ReceiptDetail: 解析されたレシートの詳細情報
         """
@@ -116,9 +116,7 @@ class OpenAIHandler:
             "content": [
                 {
                     "type": "image_url",
-                    "image_url": {
-                        "url": f"data:image/{image_type};base64,{base64_image}"
-                    },
+                    "image_url": {"url": f"data:{content_type};base64,{base64_image}"},
                 }
             ],
         }

--- a/src/receipt_scanner_model/s3_client.py
+++ b/src/receipt_scanner_model/s3_client.py
@@ -41,7 +41,7 @@ class S3Client:
 
         Returns:
             bytes: ダウンロードした画像
-            str: 画像のMIMEタイプ（例: "jpeg", "png"）
+            str: コンテントのMIMEタイプ（例: "image/jpeg", "image/png"）
         """
         try:
             # まずheadでファイルサイズを確認
@@ -72,17 +72,16 @@ class S3Client:
                 raise S3BadRequest(
                     400, f"ファイルのContent-Typeが画像ではありません: {content_type}"
                 )
-            image_type = content_type.split("/")[1].lower()
-            if image_type not in ["png", "jpeg", "jpg"]:
-                logger.error(f"サポートされていない画像形式です: {image_type}")
+            if content_type not in ["image/png", "image/jpeg"]:
+                logger.error(f"サポートされていない画像形式です: {content_type}")
                 raise S3BadRequest(
-                    400, f"サポートされていない画像形式です: {image_type}"
+                    400, f"サポートされていない画像形式です: {content_type}"
                 )
 
             # サイズ・画像タイプに問題なければダウンロード
             response = self.s3_client.get_object(Bucket=self.bucket_name, Key=filename)
             with response["Body"] as stream:
-                return stream.read(), image_type
+                return stream.read(), content_type
 
         except ClientError as e:
             error_message = e.response["Error"]["Message"]

--- a/tests/test_src/test_s3_client.py
+++ b/tests/test_src/test_s3_client.py
@@ -38,12 +38,12 @@ def setup_s3_mocks(
     mock_s3_client,
     content_length=1024,
     file_content=b"test_content",
-    image_type="image/png",
+    content_type="image/png",
 ):
     """S3モックの共通セットアップ"""
     mock_s3_client.head_object.return_value = {
         "ContentLength": content_length,
-        "ContentType": image_type,
+        "ContentType": content_type,
     }
     mock_s3_client.get_object.return_value = {"Body": io.BytesIO(file_content)}
 
@@ -73,11 +73,11 @@ def test_download_image_by_filename_success(mock_aws_s3_client, s3_client):
     """download_image_by_filenameが正常に動作することをテスト"""
     test_filename = "test_receipt.jpg"
     file_content = b"test_image_content"
-    image_type = "png"
+    content_type = "image/png"
 
     setup_s3_mocks(mock_aws_s3_client, content_length=1024, file_content=file_content)
 
-    file_content_result, image_type_result = s3_client.download_image_by_filename(
+    file_content_result, content_type_result = s3_client.download_image_by_filename(
         test_filename
     )
 
@@ -91,7 +91,7 @@ def test_download_image_by_filename_success(mock_aws_s3_client, s3_client):
 
     # 戻り値が期待通りであることを確認
     assert file_content_result == file_content
-    assert image_type_result == image_type
+    assert content_type_result == content_type
 
 
 @pytest.mark.parametrize(
@@ -113,7 +113,7 @@ def test_file_size_boundary_values(
     """境界値テスト: ファイルサイズの上限・下限値"""
     test_filename = "test_receipt.jpg"
     file_content = b"test_content"
-    image_type = "image/png"
+    content_type = "image/png"
 
     if expected_success:
         # 正常ケース
@@ -121,18 +121,18 @@ def test_file_size_boundary_values(
             mock_aws_s3_client,
             content_length=file_size,
             file_content=file_content,
-            image_type=image_type,
+            content_type=content_type,
         )
-        file_content_result, image_type_result = s3_client.download_image_by_filename(
+        file_content_result, content_type_result = s3_client.download_image_by_filename(
             test_filename
         )
         assert file_content_result == file_content
-        assert image_type_result == image_type.split("/")[1].lower()
+        assert content_type_result == content_type
     else:
         # エラーケース: head_objectのみセットアップ
         mock_aws_s3_client.head_object.return_value = {
             "ContentLength": file_size,
-            "ContentType": image_type,
+            "ContentType": content_type,
         }
         with pytest.raises(S3BadRequest) as exc_info:
             s3_client.download_image_by_filename(test_filename)


### PR DESCRIPTION
## 概要

拡張子を取得して、openaiに与えていた箇所を、content_typeをそのまま与えるようにした

## カバレッジC1

``` sh
Name                                           Stmts   Miss Branch BrPart  Cover   Missing
------------------------------------------------------------------------------------------
api/main.py                                       57      0      8      0   100%
src/receipt_scanner_model/__init__.py              0      0      0      0   100%
src/receipt_scanner_model/analyze.py               6      0      0      0   100%
src/receipt_scanner_model/error.py                24      0      0      0   100%
src/receipt_scanner_model/file_operations.py       3      0      0      0   100%
src/receipt_scanner_model/logger_config.py        33      0      2      0   100%
src/receipt_scanner_model/open_ai.py              50      0      2      0   100%
src/receipt_scanner_model/s3_client.py            56      0     18      0   100%
src/receipt_scanner_model/scan_receipt.py         78      6     28      7    88%   75->exit, 108, 119, 124, 145-146, 173->167, 179
src/receipt_scanner_model/setting.py               9      0      0      0   100%
------------------------------------------------------------------------------------------
```

#79