### PR TITLE
👷 github actionsを追加して、pre-commitとtestがCIで動くようにした (#82)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,26 +39,25 @@ jobs:
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
-          
+
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
           # model: "claude-opus-4-1-20250805"
-          
+
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"
-          
+
           # Optional: Trigger when specific user is assigned to an issue
           # assignee_trigger: "claude-bot"
-          
+
           # Optional: Allow Claude to run specific commands
           # allowed_tools: "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
-          
+
           # Optional: Add custom instructions for Claude to customize its behavior for your project
           # custom_instructions: |
           #   Follow our coding standards
           #   Ensure all new code has tests
           #   Use TypeScript for new files
-          
+
           # Optional: Custom environment variables for Claude
           # claude_env: |
           #   NODE_ENV: test
-

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,18 @@
+name: pre-commit
+
+on: push
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: eifinger/setup-rye@v4
+        id: setup-rye
+      - name: Pin python-version 3.12.4
+        run: rye pin 3.12.4
+
+      - name: Run pre-commit
+        run: |
+          rye run pre-commit install
+          rye run pre-commit run --all-files

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,8 +9,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: eifinger/setup-rye@v4
         id: setup-rye
-      - name: Pin python-version 3.12.4
-        run: rye pin 3.12.4
+      - name: Pin python-version from .python-version
+        run: rye pin "$(cat .python-version)"
       - name: Setup Rye
         run: rye sync
       - name: Run pre-commit hooks

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Run pre-commit
         run: |
           rye run pre-commit install
-          rye run pre-commit run --all-files
+          pre-commit run --all-files

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,8 +11,7 @@ jobs:
         id: setup-rye
       - name: Pin python-version 3.12.4
         run: rye pin 3.12.4
-
-      - name: Run pre-commit
-        run: |
-          rye run pre-commit install
-          pre-commit run --all-files
+      - name: Setup Rye
+        run: rye sync
+      - name: Run pre-commit hooks
+        run: rye run pre-commit run --all-files

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,13 @@ on:
       - "/investigation/**"
       - "/raw/**"
 
+env:
+  BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,8 +6,8 @@ on:
       - main
     paths-ignore:
       - "*.md"
-      - "/investigation/**"
-      - "/raw/**"
+      - "investigation/**"
+      - "raw/**"
 
 env:
   BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
@@ -27,9 +27,8 @@ jobs:
       - name: Pin python-version 3.12.4
         run: rye pin 3.12.4
       - name: Install dependencies
-        if: steps.setup-rye.outputs.cache-hit != 'true'
-        run: |
-          rye sync
-
-      - name: Run tests
-        run: rye run pytest tests
+        run: rye sync
+      - name: Run tests with coverage
+        run: rye run coverage run --branch -m pytest tests
+      - name: Generate coverage report
+        run: rye run coverage report --show-missing --include="api/*,src/*"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,8 +27,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: eifinger/setup-rye@v4
         id: setup-rye
-      - name: Pin python-version 3.12.4
-        run: rye pin 3.12.4
+      - name: Pin python-version from .python-version
+        run: rye pin "$(cat .python-version)"
       - name: Install dependencies
         run: rye sync
       - name: Run tests with coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,9 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,5 +30,9 @@ jobs:
         run: rye sync
       - name: Run tests with coverage
         run: rye run coverage run --branch -m pytest tests
-      - name: Generate coverage report
-        run: rye run coverage report --show-missing --include="api/*,src/*"
+      - name: Generate coverage XML
+        run: rye run coverage xml --include="api/*,src/*"
+      - name: Pytest coverage comment
+        uses: MishaKav/pytest-coverage-comment@main
+        with:
+          pytest-xml-coverage-path: ./coverage.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,8 +6,8 @@ on:
       - main
     paths-ignore:
       - "*.md"
-      - "/investigation/"
-      - "/raw"
+      - "/investigation/**"
+      - "/raw/**"
 
 jobs:
   test:
@@ -25,4 +25,4 @@ jobs:
           rye sync
 
       - name: Run tests
-        run: coverage run --branch -m pytest tests/
+        run: rye run pytest tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,28 @@
+name: tests
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - "*.md"
+      - "/investigation/"
+      - "/raw"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: eifinger/setup-rye@v4
+        id: setup-rye
+      - name: Pin python-version 3.12.4
+        run: rye pin 3.12.4
+      - name: Install dependencies
+        if: steps.setup-rye.outputs.cache-hit != 'true'
+        run: |
+          rye sync
+
+      - name: Run tests
+        run: coverage run --branch -m pytest tests/

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ logs/
 
 # coverage reports
 .coverage
+coverage.xml

--- a/tests/test_src/test_scan_receipt.py
+++ b/tests/test_src/test_scan_receipt.py
@@ -4,6 +4,7 @@ import os
 from src.receipt_scanner_model import scan_receipt
 from PIL import Image
 import io
+import pytest
 
 # 現在のスクリプトのディレクトリを取得
 current_dir = os.path.dirname(os.path.abspath(__file__))
@@ -12,6 +13,7 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 TEST_IMAGE_PATH = os.path.join(current_dir, "../../raw/ok.jpeg")
 
 
+@pytest.mark.skip(reason="現在使用していない")
 def test_main():
     """
     レシートの合計金額を取得する関数のテスト
@@ -25,6 +27,7 @@ def test_main():
     assert expected == actual
 
 
+@pytest.mark.skip(reason="現在使用していない")
 def test_dict_max_empty():
     """
     amount_dictが{}の場合のdict_max関数のテスト
@@ -35,6 +38,7 @@ def test_dict_max_empty():
     assert expected == actual
 
 
+@pytest.mark.skip(reason="現在使用していない")
 def test_dict_max():
     """
     dict_max関数のテスト
@@ -45,6 +49,7 @@ def test_dict_max():
     assert expected == actual
 
 
+@pytest.mark.skip(reason="現在使用していない")
 def test_get_most_likely():
     """
     get_most_likely関数のテスト


### PR DESCRIPTION
## 概要

pre-commitとtestが以下の条件でci実行されるようにした。

**pre-commit**
- 実行時:  push - 全てのブランチへのpush時
- 補足: コード品質チェック（lint、format、型チェックなど）を実行

**tests**
- 実行時: pull_request - mainブランチへのPR作成・更新時
- 補足:
  - カバレッジ付きテスト実行 (coverage run --branch -m pytest tests)
  - PR権限でカバレッジコメントをPRに追加
  - 必要な環境変数（AWS、OpenAI API）をsecrets経由で設定
  - *.md, investigation/**, raw/** ファイルのみの変更時は実行しない

## 動作確認
ciが動くことを確認

closes #82 